### PR TITLE
[Fix] 99 내명함 및 프로필 수정 페이지 label 크기 수정

### DIFF
--- a/Kerdy/Kerdy/MyProfile/VC/MyBusinessCardVC.swift
+++ b/Kerdy/Kerdy/MyProfile/VC/MyBusinessCardVC.swift
@@ -41,7 +41,8 @@ final class MyBusinessCardVC: UIViewController {
     
     private lazy var nameLabel: UILabel = {
         let label = UILabel()
-        label.text = "김커디"
+        label.text = ""
+        label.adjustsFontSizeToFitWidth = true
         label.font = .nanumSquare(to: .bold, size: 17)
         return label
     }()
@@ -269,10 +270,10 @@ final class MyBusinessCardVC: UIViewController {
         }
         
         nameLabel.snp.makeConstraints {
-            $0.width.equalTo(47)
             $0.height.equalTo(16)
             $0.top.equalToSuperview().offset(167)
             $0.leading.equalToSuperview().offset(17)
+            $0.trailing.equalTo(greenRing.snp.leading).offset(-10)
         }
         
         introduceLabel.snp.makeConstraints {

--- a/Kerdy/Kerdy/MyProfile/VC/ProfileEditVC.swift
+++ b/Kerdy/Kerdy/MyProfile/VC/ProfileEditVC.swift
@@ -45,7 +45,8 @@ final class ProfileEditVC: UIViewController, ProfileActivityCellDelegate, Profil
     
     private lazy var nameLabel: UILabel = {
        let label = UILabel()
-        label.text = "김커디"
+        label.text = ""
+        label.adjustsFontSizeToFitWidth = true
         label.font = .nanumSquare(to: .bold, size: 17)
         return label
     }()
@@ -208,12 +209,6 @@ final class ProfileEditVC: UIViewController, ProfileActivityCellDelegate, Profil
                 self?.setTags()
             })
             .disposed(by: disposeBag)
-        
-//        profileViewModel.myTags
-//            .subscribe(onNext: { [weak self] _ in
-//                self?.setTags()
-//            })
-//            .disposed(by: disposeBag)
     }
 
     private func updateUI(member: MemberProfileResponseDTO) {
@@ -289,6 +284,7 @@ final class ProfileEditVC: UIViewController, ProfileActivityCellDelegate, Profil
             $0.height.equalTo(16)
             $0.top.equalToSuperview().offset(184)
             $0.leading.equalToSuperview().offset(17)
+            $0.trailing.equalTo(greenRing.snp.leading).offset(-10)
         }
         
         descTextView.snp.makeConstraints {


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
내 명함 및 프로필 화면에서 사용자 이름 label이 잘려보이는 오류 수정

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
![simulator_screenshot_5BFB338E-B5D3-430C-B89B-A9E5E1508C8D](https://github.com/Kerdy-iOS/Kerdy-iOS/assets/99407953/9ebfcea3-3bb2-4570-9960-faf763332462)

| iPhone SE2 | iPhone 13 mini | iPhone 13 Pro |
|----|----|----|
|  |  |  |


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
label 크기 오류 수정

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #99 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
